### PR TITLE
[PrintingPodRecharge] Fixed JSON file recreation at start time

### DIFF
--- a/PrintingPodRecharge/DataGen/BundleGen.cs
+++ b/PrintingPodRecharge/DataGen/BundleGen.cs
@@ -54,9 +54,10 @@ namespace PrintingPodRecharge.DataGen
 		{
 			var filePath = Path.Combine(folder, fileName + ".json");
 
-			Log.Debuglog($"Creating pack {filePath}. {File.Exists(filePath)}");
+			Log.Debuglog($"Checking if {filePath} exists: {File.Exists(filePath)}");
 			if (force || !File.Exists(filePath))
 			{
+				Log.Debuglog($"Creating pack {filePath}");
 				Write(filePath, bundlegen());
 			}
 		}

--- a/PrintingPodRecharge/Mod.cs
+++ b/PrintingPodRecharge/Mod.cs
@@ -81,7 +81,7 @@ namespace PrintingPodRecharge
         public override void OnAllModsLoaded(Harmony harmony, IReadOnlyList<KMod.Mod> mods)
         {
             base.OnAllModsLoaded(harmony, mods);
-            DataGen.BundleGen.Generate(Path.Combine(ModAssets.GetRootPath(), "data", "bundles"), true);
+            DataGen.BundleGen.Generate(Path.Combine(ModAssets.GetRootPath(), "data", "bundles"), false);
 
             otherMods = new ModData(mods);
             if(otherMods.IsTwitchIntegrationHere)

--- a/PrintingPodRecharge/ModAssets.cs
+++ b/PrintingPodRecharge/ModAssets.cs
@@ -60,11 +60,11 @@ namespace PrintingPodRecharge
 
 			Prefabs.bioInkSideScreen = bundle.LoadAsset<GameObject>("Assets/UIs/BioInkSidescreen.prefab");
 			Log.Assert("sidescreen", Prefabs.bioInkSideScreen);
-			tmp.ReplaceAllText(Prefabs.bioInkSideScreen);
+			TMPConverter.ReplaceAllText(Prefabs.bioInkSideScreen);
 
 			Prefabs.settingsDialog = bundle.LoadAsset<GameObject>("Assets/UIs/SettingsDialog 1.prefab");
 			Log.Assert("settingsDialog", Prefabs.settingsDialog);
-			tmp.ReplaceAllText(Prefabs.settingsDialog);
+			TMPConverter.ReplaceAllText(Prefabs.settingsDialog);
 
 			StatusItems.printReady = new StatusItem(
 				"ppr_printready",

--- a/PrintingPodRecharge/Patches/LocalizationPatch.cs
+++ b/PrintingPodRecharge/Patches/LocalizationPatch.cs
@@ -1,4 +1,4 @@
-﻿using FUtility;
+﻿using FUtility.FLocalization;
 using HarmonyLib;
 
 namespace PrintingPodRecharge.Patches
@@ -10,7 +10,7 @@ namespace PrintingPodRecharge.Patches
         {
             public static void Postfix()
             {
-                Loc.Translate(typeof(STRINGS), true);
+                Translations.RegisterForTranslation(typeof(STRINGS), true);
             }
         }
     }

--- a/PrintingPodRecharge/PrintingPodRecharge.csproj
+++ b/PrintingPodRecharge/PrintingPodRecharge.csproj
@@ -3,7 +3,7 @@
 	<!-- General Package Properties -->
 	<PropertyGroup>
 		<PackageId>PrintingPodRecharge</PackageId>
-		<Version>1.3.4.0</Version>
+		<Version>1.3.5.0</Version>
 		<Authors>Aki</Authors>
 		<Copyright>2021 Aki</Copyright>
 		<RepositoryUrl>https://github.com/aki-art/ONI-Mods</RepositoryUrl>


### PR DESCRIPTION
Fixed an error where the bundle JSON files were overwritten at every startup of the game.

Tweaked the logging a bit.

Two other, unrelated small fixes, so the code can compile.