### PR TITLE
Fix U59 crashes in PrintingPodRecharge (skills screen + bio-ink sides…

### DIFF
--- a/PrintingPodRecharge/Content/Cmps/CustomDupe.cs
+++ b/PrintingPodRecharge/Content/Cmps/CustomDupe.cs
@@ -235,7 +235,8 @@ namespace PrintingPodRecharge.Content.Cmps
 			{
 				if (dupe.TryGetComponent(out MinionIdentity identity))
 				{
-					identity.personalityResourceId = dye.descKey;
+					// descKey is only for borrowed personality description text, not a Db personality id
+					UpdateIdentity(identity);
 				}
 
 				if (dye.dyedHair)

--- a/PrintingPodRecharge/Patches/SkillsScreenPatch.cs
+++ b/PrintingPodRecharge/Patches/SkillsScreenPatch.cs
@@ -1,0 +1,17 @@
+using HarmonyLib;
+using PrintingPodRecharge.Content.Cmps;
+
+namespace PrintingPodRecharge.Patches
+{
+	[HarmonyPatch(typeof(SkillsScreen), "CurrentlySelectedMinion", MethodType.Setter)]
+	public class SkillsScreen_CurrentlySelectedMinion_Patch
+	{
+		public static void Prefix(IAssignableIdentity value)
+		{
+			if (value is MinionIdentity identity)
+			{
+				CustomDupe.UpdateIdentity(identity);
+			}
+		}
+	}
+}

--- a/PrintingPodRecharge/UI/BioInkSidescreen.cs
+++ b/PrintingPodRecharge/UI/BioInkSidescreen.cs
@@ -108,6 +108,11 @@ namespace PrintingPodRecharge.UI
 
 		private void RefreshButtons()
 		{
+			if (printer == null || options.Count == 0)
+			{
+				return;
+			}
+
 			if (printer.inkTag != Tag.Invalid)
 			{
 				dropdown.interactable = false;
@@ -150,16 +155,21 @@ namespace PrintingPodRecharge.UI
 		{
 			options.Clear();
 
+			if (dropdown == null)
+			{
+				return;
+			}
+
 			foreach (var ink in Assets.GetPrefabsWithTag(ModAssets.Tags.bioInk))
 			{
-				Log.Debuglog("ink" + ink.PrefabID());
-				Log.Debuglog(ink.GetComponent<BundleModifier>() != null);
-
-				var bundle = ink.GetComponent<BundleModifier>().bundle;
-
-				if (ImmigrationModifier.Instance.IsBundleAvailable(bundle))
+				if (!ink.TryGetComponent(out BundleModifier bundleModifier))
 				{
-					Log.Debuglog("added ink " + ink.GetProperName());
+					continue;
+				}
+
+				if (ImmigrationModifier.Instance != null
+					&& ImmigrationModifier.Instance.IsBundleAvailable(bundleModifier.bundle))
+				{
 					options.Add(new Option(ink));
 				}
 			}
@@ -188,15 +198,28 @@ namespace PrintingPodRecharge.UI
 
 			printer = target.GetComponent<BioPrinter>();
 
-			if (printer == null)
+			if (printer == null || dropdown == null)
 			{
 				return;
 			}
 
-			SetInk(printer.lastInkTag);
+			AddOptions();
+
+			if (options.Count == 0)
+			{
+				SetDescription("");
+				dropdown.interactable = false;
+				actionButton.SetInteractable(false);
+				cancelButton.SetInteractable(false);
+				return;
+			}
+
+			var ink = printer.lastInkTag != Tag.Invalid ? printer.lastInkTag : printer.inkTag;
+			SetInk(ink);
 			RefreshButtons();
 
-			SetDescription(options[dropdown.value].description);
+			var index = Math.Min(dropdown.value, options.Count - 1);
+			SetDescription(options[index].description);
 		}
 
 		private int GetOptionIndex(Tag tag)
@@ -206,8 +229,16 @@ namespace PrintingPodRecharge.UI
 
 		private void SetInk(Tag ink)
 		{
+			if (dropdown == null || options.Count == 0)
+			{
+				return;
+			}
+
 			var index = GetOptionIndex(ink);
-			index = Math.Max(index, 0);
+			if (index < 0)
+			{
+				index = 0;
+			}
 
 			dropdown.value = index;
 			dropdown.RefreshShownValue();


### PR DESCRIPTION
Fixes for game build U59-737790:

1. CustomDupe.Apply — stop overwriting personalityResourceId with empty descKey
   (fixes "Could not find Personality: 0x0" on Skills screen)

2. SkillsScreen patch — repair invalid personality when selecting a dupe

3. BioInkSidescreen — guard empty dropdown when selecting Printing Pod

Tested on U59. I also maintain a credited Workshop fork (WannaPrint); happy to retire it if this merges.