### PR TITLE
PrintingPodRecharge: null-guards for custom anims + minimum build bump

### DIFF
--- a/PrintingPodRecharge/Content/Cmps/CustomDupe.cs
+++ b/PrintingPodRecharge/Content/Cmps/CustomDupe.cs
@@ -235,7 +235,8 @@ namespace PrintingPodRecharge.Content.Cmps
 			{
 				if (dupe.TryGetComponent(out MinionIdentity identity))
 				{
-					identity.personalityResourceId = dye.descKey;
+					// descKey is only for borrowed personality description text, not a Db personality id
+					UpdateIdentity(identity);
 				}
 
 				if (dye.dyedHair)

--- a/PrintingPodRecharge/Content/PAccessories.cs
+++ b/PrintingPodRecharge/Content/PAccessories.cs
@@ -11,6 +11,10 @@ namespace PrintingPodRecharge.Content
             public static void Postfix(AccessorySlots __instance, ResourceSet parent)
             {
                 var hair = Assets.GetAnim("rrp_bleachedhair_kanim");
+                if (hair == null)
+                {
+                    return;
+                }
 
                 AddAccessories(hair, __instance.Hair, parent);
                 AddAccessories(hair, __instance.HatHair, parent);

--- a/PrintingPodRecharge/Patches/KAnimGroupFilePatch.cs
+++ b/PrintingPodRecharge/Patches/KAnimGroupFilePatch.cs
@@ -21,13 +21,24 @@ namespace PrintingPodRecharge.Patches
 
             private static void MoveAnimGroup(List<KAnimGroupFile.Group> groups, int batchTagHash, string animName)
             {
-                var animsGroup = KAnimGroupFile.GetGroup(new HashedString(batchTagHash));
+                if (groups == null)
+                {
+                    return;
+                }
 
-                // remove the wrong group
-                groups.RemoveAll(g => g.animNames[0] == animName);
-
-                // readd to correct group
                 var anim = Assets.GetAnim(animName);
+                if (anim == null)
+                {
+                    return;
+                }
+
+                var animsGroup = KAnimGroupFile.GetGroup(new HashedString(batchTagHash));
+                if (animsGroup == null)
+                {
+                    return;
+                }
+
+                groups.RemoveAll(g => g.animNames != null && g.animNames.Count > 0 && g.animNames[0] == animName);
 
                 animsGroup.animFiles.Add(anim);
                 animsGroup.animNames.Add(anim.name);

--- a/PrintingPodRecharge/Patches/SkillsScreenPatch.cs
+++ b/PrintingPodRecharge/Patches/SkillsScreenPatch.cs
@@ -1,0 +1,17 @@
+using HarmonyLib;
+using PrintingPodRecharge.Content.Cmps;
+
+namespace PrintingPodRecharge.Patches
+{
+	[HarmonyPatch(typeof(SkillsScreen), "CurrentlySelectedMinion", MethodType.Setter)]
+	public class SkillsScreen_CurrentlySelectedMinion_Patch
+	{
+		public static void Prefix(IAssignableIdentity value)
+		{
+			if (value is MinionIdentity identity)
+			{
+				CustomDupe.UpdateIdentity(identity);
+			}
+		}
+	}
+}

--- a/PrintingPodRecharge/PrintingPodRecharge.csproj
+++ b/PrintingPodRecharge/PrintingPodRecharge.csproj
@@ -27,10 +27,7 @@
 		<ModName>Bio-Inks: Rechargeable Printing Pod</ModName>
 		<ModDescription>Printing Pods can be recharged with Bio Ink.</ModDescription>
 		<SupportedContent>ALL</SupportedContent>
-		<MinimumSupportedBuild>
-			561314
-			<!--549456-->
-	</MinimumSupportedBuild>
+		<MinimumSupportedBuild>670711</MinimumSupportedBuild>
 		<APIVersion>2</APIVersion>
 	</PropertyGroup>
 

--- a/PrintingPodRecharge/UI/BioInkSidescreen.cs
+++ b/PrintingPodRecharge/UI/BioInkSidescreen.cs
@@ -108,6 +108,11 @@ namespace PrintingPodRecharge.UI
 
 		private void RefreshButtons()
 		{
+			if (printer == null || options.Count == 0)
+			{
+				return;
+			}
+
 			if (printer.inkTag != Tag.Invalid)
 			{
 				dropdown.interactable = false;
@@ -150,16 +155,21 @@ namespace PrintingPodRecharge.UI
 		{
 			options.Clear();
 
+			if (dropdown == null)
+			{
+				return;
+			}
+
 			foreach (var ink in Assets.GetPrefabsWithTag(ModAssets.Tags.bioInk))
 			{
-				Log.Debuglog("ink" + ink.PrefabID());
-				Log.Debuglog(ink.GetComponent<BundleModifier>() != null);
-
-				var bundle = ink.GetComponent<BundleModifier>().bundle;
-
-				if (ImmigrationModifier.Instance.IsBundleAvailable(bundle))
+				if (!ink.TryGetComponent(out BundleModifier bundleModifier))
 				{
-					Log.Debuglog("added ink " + ink.GetProperName());
+					continue;
+				}
+
+				if (ImmigrationModifier.Instance != null
+					&& ImmigrationModifier.Instance.IsBundleAvailable(bundleModifier.bundle))
+				{
 					options.Add(new Option(ink));
 				}
 			}
@@ -188,15 +198,28 @@ namespace PrintingPodRecharge.UI
 
 			printer = target.GetComponent<BioPrinter>();
 
-			if (printer == null)
+			if (printer == null || dropdown == null)
 			{
 				return;
 			}
 
-			SetInk(printer.lastInkTag);
+			AddOptions();
+
+			if (options.Count == 0)
+			{
+				SetDescription("");
+				dropdown.interactable = false;
+				actionButton.SetInteractable(false);
+				cancelButton.SetInteractable(false);
+				return;
+			}
+
+			var ink = printer.lastInkTag != Tag.Invalid ? printer.lastInkTag : printer.inkTag;
+			SetInk(ink);
 			RefreshButtons();
 
-			SetDescription(options[dropdown.value].description);
+			var index = Math.Min(dropdown.value, options.Count - 1);
+			SetDescription(options[index].description);
 		}
 
 		private int GetOptionIndex(Tag tag)
@@ -206,8 +229,16 @@ namespace PrintingPodRecharge.UI
 
 		private void SetInk(Tag ink)
 		{
+			if (dropdown == null || options.Count == 0)
+			{
+				return;
+			}
+
 			var index = GetOptionIndex(ink);
-			index = Math.Max(index, 0);
+			if (index < 0)
+			{
+				index = 0;
+			}
 
 			dropdown.value = index;
 			dropdown.RefreshShownValue();


### PR DESCRIPTION
## Summary

- Add null checks in `KAnimGroupFilePatch.MoveAnimGroup` when anim groups or kanim assets are missing
- Skip bleached-hair accessories in `PAccessories` if the kanim failed to load
- Raise `MinimumSupportedBuild` from `561314` to `670711`

Complements #125 (skills screen + bio-ink sidescreen fixes). This branch includes that commit; merge #125 first or merge this PR after #125.

## Test plan

- [ ] Load a save with Printing Pod on build U59 (737790)
- [ ] Open skills screen for dupes with bio-ink traits — no crash
- [ ] Click Printing Pod — bio-ink sidescreen opens without NRE
- [ ] Start/load game without mod anim assets present — no crash on boot