### PR TITLE
fix(truetiles): port to U59 (AddBlock + RenderInfo ctor overloads)

### DIFF
--- a/TrueTiles/Patches/BlockTileRendererPatch.cs
+++ b/TrueTiles/Patches/BlockTileRendererPatch.cs
@@ -82,7 +82,10 @@ namespace TrueTiles.Patches
 			}
 		}
 
-		[HarmonyPatch(typeof(BlockTileRenderer), "AddBlock")]
+		// U59 added a second AddBlock overload (extra trailing bool), making a name-only
+		// patch ambiguous and aborting PatchAll. Target the real worker overload explicitly;
+		// the 5-arg overload is just a wrapper that forwards into this one.
+		[HarmonyPatch(typeof(BlockTileRenderer), "AddBlock", new Type[] { typeof(int), typeof(BuildingDef), typeof(bool), typeof(SimHashes), typeof(int), typeof(bool) })]
 		public static class Rendering_BlockTileRenderer_AddBlock_Patch
 		{
 			public static IEnumerable<CodeInstruction> Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> orig)

--- a/TrueTiles/Patches/RenderInfoPatch.cs
+++ b/TrueTiles/Patches/RenderInfoPatch.cs
@@ -13,11 +13,14 @@ namespace TrueTiles.Patches
 		[HarmonyPatch]
 		public static class RenderInfo_Ctor_Patch
 		{
-			// Private type so it needs to be targeted like this
+			// Private type so it needs to be targeted like this.
+			// U59 added a trailing bool (isBlueprint) overload; the game now builds RenderInfo
+			// through the 6-arg ctor (the 5-arg one is just a forwarding wrapper), so target that
+			// one explicitly or the texture-setting postfix never runs.
 			public static MethodBase TargetMethod()
 			{
 				var type = AccessTools.TypeByName("Rendering.BlockTileRenderer+RenderInfo");
-				return AccessTools.Constructor(type, new Type[] { typeof(BlockTileRenderer), typeof(int), typeof(int), typeof(BuildingDef), typeof(SimHashes) });
+				return AccessTools.Constructor(type, new Type[] { typeof(BlockTileRenderer), typeof(int), typeof(int), typeof(BuildingDef), typeof(SimHashes), typeof(bool) });
 			}
 
 			public static void Postfix(BuildingDef def, SimHashes element, Material ___material, object ___decorRenderInfo)


### PR DESCRIPTION
After the **U59** game update, True Tiles fails to load and, once loadable, no longer applies any tile textures. Both are the same U59 refactor pattern on `Rendering.BlockTileRenderer`: a method/ctor got a **new overload with a trailing `bool`**, the original signature became a thin forwarding wrapper, and the game now calls the new overload — so patches that target the old signature by name/arity either throw or silently no-op.

## 1. Load crash — `AddBlock` ambiguity

```
HarmonyLib.HarmonyException: Ambiguous match for HarmonyMethod[(class=Rendering.BlockTileRenderer, methodname=AddBlock, ...)]
 ---> System.Reflection.AmbiguousMatchException: Ambiguous match found.
   at HarmonyLib.AccessTools.DeclaredMethod (...)
   at TrueTiles.Mod.OnLoad (...)
```

U59 added a second overload, so the name-only `[HarmonyPatch]` matches two methods and aborts `PatchAll` (`Failed to load mod True Tiles...disabling`):

| Overload | Role |
|---|---|
| `AddBlock(int, BuildingDef, bool, SimHashes, int)` | thin wrapper |
| `AddBlock(int, BuildingDef, bool, SimHashes, int, bool)` | real worker (has the `GetRenderInfoLayer` call the transpiler hooks) |

**Fix:** target the worker overload explicitly via argument types. Transpiler body unchanged — arg positions (`def`=2, element=4) are identical since the new `bool` is appended.

## 2. No textures — `RenderInfo` ctor

With #1 fixed the mod loads cleanly but tiles show no override, on any save (not a new-colony issue). `RenderInfo_Ctor_Patch` postfixes the private `BlockTileRenderer+RenderInfo` constructor to set the material textures, but U59 gave that ctor the same treatment:

| Ctor | Role |
|---|---|
| `RenderInfo(BlockTileRenderer, int, int, BuildingDef, SimHashes)` | forwarding wrapper |
| `RenderInfo(..., SimHashes, bool /*isBlueprint*/)` | the one `AddBlock` actually `newobj`s |

`TargetMethod()` resolved the 5-arg ctor (still present, so the patch applied with no error) but the render path only builds via the 6-arg ctor, so the texture-setting postfix never ran.

**Fix:** add `typeof(bool)` so `TargetMethod()` resolves the 6-arg ctor. Postfix unchanged — `def`/`element` still match by name, `isBlueprint` is ignored.

## Validation (Linux, .NET SDK 8 + U59 game libs)

- **Reflection** (the exact path `AccessTools` → `Type.GetMethod/Constructor` takes): the name-only `AddBlock` lookup throws `AmbiguousMatchException`; the 6-type lookup resolves to exactly one method. The 6-arg `RenderInfo` ctor is confirmed as the one `AddBlock` constructs, and its params are `(renderer, queryLayer, renderLayer, def, element, isBlueprint)`.
- **Compile** of the changed files against the U59 game DLLs succeeds.
- **In-game**: with both fixes applied the mod loads with a clean log and tile textures render correctly on a pre-existing colony.

I couldn't run the full mod build on Linux (needs the sibling FUtility project + publicised assemblies + the Windows-only ILRepack/xcopy targets), so a CI/Windows build check is still worthwhile.
